### PR TITLE
fix #10

### DIFF
--- a/lib/mongoose-core.module.ts
+++ b/lib/mongoose-core.module.ts
@@ -1,16 +1,17 @@
 import * as mongoose from 'mongoose';
 import { Module, DynamicModule, Global } from '@nestjs/common';
 import { from } from 'rxjs';
+import { DefaultDbConnectionToken } from './mongoose.constants';
 import { handleRetry } from './mongoose.utils';
 
 @Global()
 @Module({})
 export class MongooseCoreModule {
-  static forRoot(uri: string, options: any = {}): DynamicModule {
+  static forRoot(uri: string, options: any = {}, connectionName: string = DefaultDbConnectionToken): DynamicModule {
     const connectionProvider = {
-      provide: 'DbConnectionToken',
+      provide: connectionName,
       useFactory: async (): Promise<any> =>
-        await from(mongoose.connect(uri, options))
+        await from(mongoose.createConnection(uri, options))
           .pipe(handleRetry)
           .toPromise(),
     };

--- a/lib/mongoose.constants.ts
+++ b/lib/mongoose.constants.ts
@@ -1,0 +1,1 @@
+export const DefaultDbConnectionToken: string = 'DbConnectionToken';

--- a/lib/mongoose.module.ts
+++ b/lib/mongoose.module.ts
@@ -1,21 +1,23 @@
 import { Module, DynamicModule, Global } from '@nestjs/common';
 
+import { DefaultDbConnectionToken } from './mongoose.constants';
 import { createMongooseProviders } from './mongoose.providers';
 import { MongooseCoreModule } from './mongoose-core.module';
 
 @Module({})
 export class MongooseModule {
-  static forRoot(uri: string, options: any = {}): DynamicModule {
+  static forRoot(uri: string, options: any = {}, connectionName: string = DefaultDbConnectionToken): DynamicModule {
     return {
       module: MongooseModule,
-      imports: [MongooseCoreModule.forRoot(uri, options)],
+      imports: [MongooseCoreModule.forRoot(uri, options, connectionName)],
     };
   }
 
   static forFeature(
     models: { name: string; schema: any }[] = [],
+    connectionName: string = DefaultDbConnectionToken,
   ): DynamicModule {
-    const providers = createMongooseProviders(models);
+    const providers = createMongooseProviders(connectionName, models);
     return {
       module: MongooseModule,
       providers: providers,

--- a/lib/mongoose.providers.ts
+++ b/lib/mongoose.providers.ts
@@ -1,14 +1,16 @@
 import * as mongoose from 'mongoose';
 
+import { DefaultDbConnectionToken } from './mongoose.constants';
 import { getModelToken } from './mongoose.utils';
 
 export function createMongooseProviders(
+  connectionName: string = DefaultDbConnectionToken,
   models: { name: string; schema: mongoose.Schema }[] = [],
 ) {
   const providers = (models || []).map((model) => ({
     provide: getModelToken(model.name),
     useFactory: (connection) => connection.model(model.name, model.schema),
-    inject: ['DbConnectionToken'],
+    inject: [connectionName],
   }));
   return providers;
 }


### PR DESCRIPTION
I have tried to have it backwards compatible and just extend it with the optional database connection name in both `MongooseModule.forRoot` as well as `MongooseModule.forFeature()` methods:

``` mongoos.model.d.ts
export declare class MongooseModule {
    static forRoot(uri: string, options?: mongoose.ConnectionOptions, name?: string): DynamicModule;
    static forFeature(models?: {
        name: string;
        schema: mongoose.Schema;
    }[], connection?: string): DynamicModule;
}
```
