### PR TITLE
add reflect-metadata@^0.1.12 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "peerDependencies": {
     "@nestjs/common": "^5.0.0",
     "mongoose": "^5.0.1",
+    "reflect-metadata": "^0.1.12",
     "rxjs": "^6.0.0"
   },
   "lint-staged": {


### PR DESCRIPTION
> @nestjs/common@5.0.0 requires a peer of reflect-metadata@^0.1.12 but none was installed.