### PR TITLE
fix: make `name` in InjectConnection optional

### DIFF
--- a/lib/common/mongoose.decorators.ts
+++ b/lib/common/mongoose.decorators.ts
@@ -4,5 +4,5 @@ import { getConnectionToken, getModelToken } from './mongoose.utils';
 
 export const InjectModel = (model: string) => Inject(getModelToken(model));
 
-export const InjectConnection = (name: string) =>
+export const InjectConnection = (name?: string) =>
   Inject(name ? getConnectionToken(name) : DEFAULT_DB_CONNECTION);


### PR DESCRIPTION
I don't think this was your intended usage:
![image](https://user-images.githubusercontent.com/4655972/44600699-172d7700-a7a8-11e8-94c7-cce8aa6a5019.png)

Looks like your intent was for this to default to the default db connection if not passed anything.

https://github.com/nestjs/mongoose/blob/master/lib/common/mongoose.decorators.ts#L8
