### PR TITLE
feature(testing): expose default connection name

### DIFF
--- a/lib/common/mongoose.decorators.ts
+++ b/lib/common/mongoose.decorators.ts
@@ -1,8 +1,7 @@
 import { Inject } from '@nestjs/common';
-import { DEFAULT_DB_CONNECTION } from '../mongoose.constants';
 import { getConnectionToken, getModelToken } from './mongoose.utils';
 
 export const InjectModel = (model: string) => Inject(getModelToken(model));
 
 export const InjectConnection = (name?: string) =>
-  Inject(name ? getConnectionToken(name) : DEFAULT_DB_CONNECTION);
+  Inject(getConnectionToken(name));

--- a/lib/common/mongoose.utils.ts
+++ b/lib/common/mongoose.utils.ts
@@ -1,13 +1,14 @@
 import { Logger } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { delay, retryWhen, scan } from 'rxjs/operators';
+import { DEFAULT_DB_CONNECTION } from '../mongoose.constants';
 
 export function getModelToken(model: string) {
   return `${model}Model`;
 }
 
-export function getConnectionToken(name: string) {
-  return `${name}Connection`;
+export function getConnectionToken(name?: string) {
+  return name ? `${name}Connection` : DEFAULT_DB_CONNECTION;
 }
 
 export function handleRetry(

--- a/lib/mongoose-core.module.ts
+++ b/lib/mongoose-core.module.ts
@@ -15,7 +15,6 @@ import {
   MongooseOptionsFactory,
 } from './interfaces/mongoose-options.interface';
 import {
-  DEFAULT_DB_CONNECTION,
   MONGOOSE_CONNECTION_NAME,
   MONGOOSE_MODULE_OPTIONS,
 } from './mongoose.constants';
@@ -39,9 +38,7 @@ export class MongooseCoreModule {
       ...mongooseOptions
     } = options;
 
-    const mongooseConnectionName = connectionName
-      ? getConnectionToken(connectionName)
-      : DEFAULT_DB_CONNECTION;
+    const mongooseConnectionName = getConnectionToken(connectionName);
 
     const mongooseConnectionNameProvider = {
       provide: MONGOOSE_CONNECTION_NAME,
@@ -64,9 +61,7 @@ export class MongooseCoreModule {
   }
 
   static forRootAsync(options: MongooseModuleAsyncOptions): DynamicModule {
-    const mongooseConnectionName = options.connectionName
-      ? getConnectionToken(options.connectionName)
-      : DEFAULT_DB_CONNECTION;
+    const mongooseConnectionName = getConnectionToken(options.connectionName);
 
     const mongooseConnectionNameProvider = {
       provide: MONGOOSE_CONNECTION_NAME,

--- a/lib/mongoose.module.ts
+++ b/lib/mongoose.module.ts
@@ -4,7 +4,6 @@ import {
   MongooseModuleOptions,
 } from './interfaces/mongoose-options.interface';
 import { MongooseCoreModule } from './mongoose-core.module';
-import { DEFAULT_DB_CONNECTION } from './mongoose.constants';
 import { createMongooseProviders } from './mongoose.providers';
 
 @Module({})
@@ -28,7 +27,7 @@ export class MongooseModule {
 
   static forFeature(
     models: { name: string; schema: any; collection?: string }[] = [],
-    connectionName: string = DEFAULT_DB_CONNECTION,
+    connectionName: string,
   ): DynamicModule {
     const providers = createMongooseProviders(connectionName, models);
     return {

--- a/lib/mongoose.providers.ts
+++ b/lib/mongoose.providers.ts
@@ -1,20 +1,15 @@
 import { Connection, Schema } from 'mongoose';
 import { getConnectionToken, getModelToken } from './common/mongoose.utils';
-import { DEFAULT_DB_CONNECTION } from './mongoose.constants';
 
 export function createMongooseProviders(
-  connectionName: string = DEFAULT_DB_CONNECTION,
+  connectionName: string,
   models: { name: string; schema: Schema; collection?: string }[] = [],
 ) {
   const providers = (models || []).map(model => ({
     provide: getModelToken(model.name),
     useFactory: (connection: Connection) =>
       connection.model(model.name, model.schema, model.collection),
-    inject: [
-      connectionName === DEFAULT_DB_CONNECTION
-        ? DEFAULT_DB_CONNECTION
-        : getConnectionToken(connectionName),
-    ],
+    inject: [getConnectionToken(connectionName)],
   }));
   return providers;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) -> No tests found
- [ ] Docs have been added / updated (for bug fixes / features) -> No


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #29
The default connection name was not exposed before. It is needed e.g. in tests to mock the default connection.

## What is the new behavior?
Now, `getConnectionToken() `returns the default token. This is not a breaking change, because `getConnectionToken `could not be called without the name parameter before. It is now optional.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
