### PR TITLE
Close database connection on app shutdown

### DIFF
--- a/lib/mongoose-core.module.ts
+++ b/lib/mongoose-core.module.ts
@@ -3,6 +3,7 @@ import {
   Global,
   Inject,
   Module,
+  OnApplicationShutdown,
   Provider,
   Type,
 } from '@nestjs/common';
@@ -22,7 +23,7 @@ import {
 
 @Global()
 @Module({})
-export class MongooseCoreModule {
+export class MongooseCoreModule implements OnApplicationShutdown {
   constructor(
     @Inject(MONGOOSE_CONNECTION_NAME) private readonly connectionName: string,
     private readonly moduleRef: ModuleRef,
@@ -111,7 +112,7 @@ export class MongooseCoreModule {
     };
   }
 
-  async onModuleDestroy() {
+  async onApplicationShutdown() {
     const connection = this.moduleRef.get<any>(this.connectionName);
     connection && (await connection.close());
   }


### PR DESCRIPTION
Close database connection on app shutdown instead of on module destroy

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

When closing a Nest http application, the order of hook is :
- `onModuleDestroy`
- `beforeApplicationShutdown`
- dispose http adapter
- `onApplicationShutdown`

The mongoose core module closes the database connections with the `onModuleDestroy` hook, before the dispose of http adapter. So, the connections to database are closed before the end of http active connections.

Issue Number: N/A


## What is the new behavior?

The database connection are closed with the `onApplicationShutdown` hook after the end of http connection.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

If have found a similar issue in @nestjs/typeorm project : https://github.com/nestjs/typeorm/pull/164
