### PR TITLE
bugfix(): write error messages to the overrode log

### DIFF
--- a/lib/common/mongoose.utils.ts
+++ b/lib/common/mongoose.utils.ts
@@ -17,7 +17,7 @@ export function handleRetry(
   retryAttempts = 9,
   retryDelay = 3000,
 ): <T>(source: Observable<T>) => Observable<T> {
-  const logger = new Logger('MongooseModule', true);
+  const logger = new Logger('MongooseModule');
   return <T>(source: Observable<T>) =>
     source.pipe(
       retryWhen(e =>

--- a/lib/common/mongoose.utils.ts
+++ b/lib/common/mongoose.utils.ts
@@ -17,16 +17,16 @@ export function handleRetry(
   retryAttempts = 9,
   retryDelay = 3000,
 ): <T>(source: Observable<T>) => Observable<T> {
+  const logger = new Logger('MongooseModule', true);
   return <T>(source: Observable<T>) =>
     source.pipe(
       retryWhen(e =>
         e.pipe(
           scan((errorCount, error) => {
-            Logger.error(
+            logger.error(
               `Unable to connect to the database. Retrying (${errorCount +
                 1})...`,
               '',
-              'MongooseModule',
             );
             if (errorCount + 1 >= retryAttempts) {
               throw error;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Static method writes error messages to the stdout
```
...
{"ts":"2020-01-24T15:34:46.411Z","logger":"myLogger","level":"info","message":"ConfigModule dependencies initialized"}
{"ts":"2020-01-24T15:33:24.763Z","logger":"myLogger","level":"info","message":"WinstonModule dependencies initialized"}
[Nest] 31912   - 01/24/2020, 6:33:54 PM   Unable to connect to the database. Retrying (1)...
[Nest] 31912   - 01/24/2020, 6:34:27 PM   Unable to connect to the database. Retrying (2)... +33010ms
...
```

## What is the new behavior?
I would like to write error messages to the current logger
```
...
{"ts":"2020-01-24T15:34:46.411Z","logger":"myLogger","level":"info","message":"ConfigModule dependencies initialized"}
{"ts":"2020-01-24T15:33:24.763Z","logger":"myLogger","level":"info","message":"WinstonModule dependencies initialized"}
{"ts":"2020-01-24T15:33:24.763Z","logger":"myLogger","level":"error","message":"Unable to connect to the database. Retrying (1)..."}
{"ts":"2020-01-24T15:33:24.763Z","logger":"myLogger","level":"error","message":"Unable to connect to the database. Retrying (2)..."}

```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
n/a