### PR TITLE
Aligned MongooseModuleOptions with MongooseModuleAsyncOptions

### DIFF
--- a/lib/interfaces/mongoose-options.interface.ts
+++ b/lib/interfaces/mongoose-options.interface.ts
@@ -3,7 +3,7 @@ import { ModuleMetadata } from '@nestjs/common/interfaces';
 import { ConnectionOptions } from 'mongoose';
 
 export interface MongooseModuleOptions extends ConnectionOptions {
-  uri?: string;
+  uri: string;
   retryAttempts?: number;
   retryDelay?: number;
   connectionName?: string;

--- a/lib/mongoose-core.module.ts
+++ b/lib/mongoose-core.module.ts
@@ -29,10 +29,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
     private readonly moduleRef: ModuleRef,
   ) {}
 
-  static forRoot(
-    uri: string,
-    options: MongooseModuleOptions = {},
-  ): DynamicModule {
+  static forRoot(options: MongooseModuleOptions): DynamicModule {
     const {
       retryAttempts,
       retryDelay,
@@ -54,7 +51,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
       useFactory: async (): Promise<any> =>
         await defer(async () =>
           mongooseConnectionFactory(
-            mongoose.createConnection(uri, mongooseOptions),
+            mongoose.createConnection(options.uri, mongooseOptions),
             mongooseConnectionName,
           ),
         )
@@ -95,10 +92,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
 
         return await defer(async () =>
           mongooseConnectionFactory(
-            mongoose.createConnection(
-              mongooseModuleOptions.uri as string,
-              mongooseOptions,
-            ),
+            mongoose.createConnection(uri, mongooseOptions),
             mongooseConnectionName,
           ),
         )

--- a/lib/mongoose.module.ts
+++ b/lib/mongoose.module.ts
@@ -12,13 +12,10 @@ import {
 
 @Module({})
 export class MongooseModule {
-  static forRoot(
-    uri: string,
-    options: MongooseModuleOptions = {},
-  ): DynamicModule {
+  static forRoot(options: MongooseModuleOptions): DynamicModule {
     return {
       module: MongooseModule,
-      imports: [MongooseCoreModule.forRoot(uri, options)],
+      imports: [MongooseCoreModule.forRoot(options)],
     };
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Other... Please describe: Refactoring with API changes
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Options aren't really aligned and don't make sense.

Issue Number: https://github.com/nestjs/mongoose/issues/244


## What is the new behavior?
See linked issue for description.

## Does this PR introduce a breaking change?
```
[X] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Applications will need to move from this: `MongooseCoreModule.forRoot('mongooseUri', {})` to this -> `MongooseCoreModule.forRoot({uri: 'mongooseUri'})`

Should be an easy migration

## Other information

I'll create a squash & merge so we have 1 clean commit msg