### PR TITLE
remove @types/mongoose from pearDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   "peerDependencies": {
     "@nestjs/common": "^6.0.0 || ^7.0.0",
     "@nestjs/core": "^6.0.0 || ^7.0.0",
-    "@types/mongoose": "^5.0.0",
     "mongoose": "^5.4.19",
     "reflect-metadata": "^0.1.12",
     "rxjs": "^6.0.0"


### PR DESCRIPTION
it is not needed for this library to work in production environment

currently npm is complaining when `@nestjs/mongoose` is installed for production and `@types/mongoose` is a devDependancy (as expected)
> npm WARN @nestjs/mongoose@7.0.1 requires a peer of @types/mongoose@^5.0.0 but none is installed. You must install peer dependencies yourself.