### PR TITLE
feat(): support overwriting discriminator value instead of using model name

### DIFF
--- a/lib/interfaces/model-definition.interface.ts
+++ b/lib/interfaces/model-definition.interface.ts
@@ -3,6 +3,7 @@ import { Schema } from 'mongoose';
 export type DiscriminatorOptions = {
   name: string;
   schema: Schema;
+  value?: string;
 };
 
 export type ModelDefinition = {

--- a/lib/mongoose.providers.ts
+++ b/lib/mongoose.providers.ts
@@ -13,7 +13,7 @@ export function createMongooseProviders(
       ...(option.discriminators || []).map((d) => ({
         provide: getModelToken(d.name),
         useFactory: (model: Model<Document>) =>
-          model.discriminator(d.name, d.schema),
+          model.discriminator(d.name, d.schema, d.value),
         inject: [getModelToken(option.name)],
       })),
       {
@@ -56,7 +56,7 @@ export function createMongooseAsyncProviders(
       ...(option.discriminators || []).map((d) => ({
         provide: getModelToken(d.name),
         useFactory: (model: Model<Document>) =>
-          model.discriminator(d.name, d.schema),
+          model.discriminator(d.name, d.schema, d.value),
         inject: [getModelToken(option.name)],
       })),
     ];

--- a/tests/e2e/discriminator.spec.ts
+++ b/tests/e2e/discriminator.spec.ts
@@ -6,7 +6,7 @@ import { MongooseModule } from '../../lib';
 import { EventModule } from '../src/event/event.module';
 import {
   ClickLinkEvent,
-  ClieckLinkEventSchema,
+  ClickLinkEventSchema,
 } from '../src/event/schemas/click-link-event.schema';
 import { Event, EventSchema } from '../src/event/schemas/event.schema';
 import {
@@ -22,7 +22,11 @@ const testCase: [string, DynamicModule][] = [
         name: Event.name,
         schema: EventSchema,
         discriminators: [
-          { name: ClickLinkEvent.name, schema: ClieckLinkEventSchema },
+          {
+            name: ClickLinkEvent.name,
+            schema: ClickLinkEventSchema,
+            value: 'click_link',
+          },
           { name: SignUpEvent.name, schema: SignUpEventSchema },
         ],
       },
@@ -35,7 +39,11 @@ const testCase: [string, DynamicModule][] = [
         name: Event.name,
         useFactory: async () => EventSchema,
         discriminators: [
-          { name: ClickLinkEvent.name, schema: ClieckLinkEventSchema },
+          {
+            name: ClickLinkEvent.name,
+            schema: ClickLinkEventSchema,
+            value: 'click_link',
+          },
           { name: SignUpEvent.name, schema: SignUpEventSchema },
         ],
       },
@@ -72,7 +80,7 @@ describe.each(testCase)('Discriminator - %s', (_, features) => {
     expect(response.status).toBe(HttpStatus.CREATED);
     expect(response.body).toMatchObject({
       ...createDto,
-      kind: expect.any(String),
+      kind: expect.stringMatching('click_link'),
       time: expect.any(String),
     });
   });
@@ -85,7 +93,7 @@ describe.each(testCase)('Discriminator - %s', (_, features) => {
     expect(response.status).toBe(HttpStatus.CREATED);
     expect(response.body).toMatchObject({
       ...createDto,
-      kind: expect.any(String),
+      kind: expect.stringMatching(SignUpEvent.name),
       time: expect.any(String),
     });
   });

--- a/tests/src/event/event.controller.ts
+++ b/tests/src/event/event.controller.ts
@@ -2,7 +2,6 @@ import { Body, Controller, Get, Post } from '@nestjs/common';
 import { CreateClickLinkEventDto } from './dto/create-click-link-event.dto';
 import { CreateSignUpEventDto } from './dto/create-sign-up-event.dto';
 import { EventService } from './event.service';
-import { ClickLinkEvent } from './schemas/click-link-event.schema';
 import { Event } from './schemas/event.schema';
 import { SignUpEvent } from './schemas/sign-up-event.schema';
 
@@ -17,7 +16,7 @@ export class EventController {
     return this.eventService.create({
       ...dto,
       time: new Date(),
-      kind: ClickLinkEvent.name,
+      kind: 'click_link',
     });
   }
 

--- a/tests/src/event/schemas/click-link-event.schema.ts
+++ b/tests/src/event/schemas/click-link-event.schema.ts
@@ -11,6 +11,6 @@ export class ClickLinkEvent implements Event {
   url: string;
 }
 
-export const ClieckLinkEventSchema = SchemaFactory.createForClass(
+export const ClickLinkEventSchema = SchemaFactory.createForClass(
   ClickLinkEvent,
 );

--- a/tests/src/event/schemas/event.schema.ts
+++ b/tests/src/event/schemas/event.schema.ts
@@ -1,5 +1,4 @@
 import { Prop, Schema, SchemaFactory } from '../../../../lib';
-import { ClickLinkEvent } from './click-link-event.schema';
 import { SignUpEvent } from './sign-up-event.schema';
 
 @Schema({ discriminatorKey: 'kind' })
@@ -7,7 +6,7 @@ export class Event {
   @Prop({
     type: String,
     required: true,
-    enum: [ClickLinkEvent.name, SignUpEvent.name],
+    enum: ['click_link', SignUpEvent.name],
   })
   kind: string;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

For now, only model names are supported for discriminator values. You can't overwrite it with your own custom value.
By default, Mongoose uses the model name as the discriminator value.

```
MongooseModule.forFeature([
  {
    name: Event.name,
    schema: EventSchema,
    discriminators: [
      { name: ClickLinkEvent.name, schema: ClickLinkEventSchema },
      { name: SignUpEvent.name, schema: SignUpEventSchema },
    ],
  },
])
```


## What is the new behavior?

```
MongooseModule.forFeature([
  {
    name: Event.name,
    schema: EventSchema,
    discriminators: [
      {
        name: ClickLinkEvent.name,
        schema: ClickLinkEventSchema,
        value: 'click_link', /** With this PR, you can overwrite the default value */
      },
      { name: SignUpEvent.name, schema: SignUpEventSchema },
    ],
  },
])
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```