### PR TITLE
feat: added instance methods

### DIFF
--- a/lib/factories/schema.factory.ts
+++ b/lib/factories/schema.factory.ts
@@ -14,9 +14,23 @@ export class SchemaFactory {
     const schemaMetadata = TypeMetadataStorage.getSchemaMetadataByTarget(
       target,
     );
-    return new mongoose.Schema<TDocument>(
+    const schema = new mongoose.Schema<TDocument>(
       schemaDefinition,
       schemaMetadata && schemaMetadata.options,
     );
+    
+    // iterares over the methods of the target class
+    // and maps the functions to the schema methods
+    // reference https://mongoosejs.com/docs/guide.html#methods
+    for (const propName of Object.getOwnPropertyNames(target.prototype)) {
+      const prop = target.prototype[propName];
+      // maps only the functions and ignores the constructor
+      if (typeof prop == 'function' && propName != 'constructor') {
+        schema.methods[propName] = prop;
+      }
+    }
+
+    return schema;
   }
 }
+


### PR DESCRIPTION
- added instance method of model as mongoose instance models

## PR Type
This PR it to add improvement on the `SchemaFactory.createForClass` function. It now includes the **instance methods** feature of mongoose (refer [here](https://mongoosejs.com/docs/guide.html#methods)). It includes the functionality for adding instance methods on the schema class and having those methods available in the documents that will be instantiated from that schema object.

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When a schema is defined using the @nest/mongoose package it ignores the instance methods of the model when a model is instantiated by the mongoose.

## What is the new behavior?
It now will have the instance methods defined in the schema class as parts of the instantiated documents of the schema.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
