### PR TITLE
fix(mongooose-core-module): wait for connection in forRootAsync

### DIFF
--- a/lib/mongoose-core.module.ts
+++ b/lib/mongoose-core.module.ts
@@ -97,10 +97,12 @@ export class MongooseCoreModule implements OnApplicationShutdown {
         return await lastValueFrom(
           defer(async () =>
             mongooseConnectionFactory(
-              mongoose.createConnection(
-                mongooseModuleOptions.uri as string,
-                mongooseOptions,
-              ),
+              await mongoose
+                .createConnection(
+                  mongooseModuleOptions.uri as string,
+                  mongooseOptions,
+                )
+                .asPromise(),
               mongooseConnectionName,
             ),
           ).pipe(


### PR DESCRIPTION
Currently the connection is only awaited if using the forRoot method.
Add this behavior to the forRootAsync as well.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1082


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information