### PR TITLE
fix(decorators): avoid setting `type` property on globals like `String` and `Date`

### DIFF
--- a/lib/decorators/prop.decorator.ts
+++ b/lib/decorators/prop.decorator.ts
@@ -25,7 +25,7 @@ export function Prop(options?: PropOptions): PropertyDecorator {
 
       if (type === Array) {
         options.type = [];
-      } elseif (typeof type === 'function') {
+      } else if (typeof type === 'function') {
         options = { type: type };
       } else if (type && type !== Object) {
         options.type = type;

--- a/lib/decorators/prop.decorator.ts
+++ b/lib/decorators/prop.decorator.ts
@@ -25,6 +25,8 @@ export function Prop(options?: PropOptions): PropertyDecorator {
 
       if (type === Array) {
         options.type = [];
+      } elseif (typeof type === 'function') {
+        options = { type: type };
       } else if (type && type !== Object) {
         options.type = type;
       } else {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`@Prop(String)` results in Nest setting `String.type = String`, which has caused some issues in Mongoose: https://github.com/Automattic/mongoose/issues/11199, https://github.com/Automattic/mongoose/issues/10807

Issue Number: N/A


## What is the new behavior?

`@Prop(String)` treated as `@Prop({ type: String })`

## Does this PR introduce a breaking change?
- [ ] Yes
- [X ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
