### PR TITLE
ref function can return string

### DIFF
--- a/lib/factories/definitions.factory.ts
+++ b/lib/factories/definitions.factory.ts
@@ -94,8 +94,8 @@ export class DefinitionsFactory {
     }
     if (typeof optionsOrType?.ref === 'function') {
       try {
-        optionsOrType.ref =
-          (optionsOrType.ref as Function)()?.name ?? optionsOrType.ref;
+        const result = (optionsOrType.ref as Function)();
+        optionsOrType.ref = result?.name ?? result;
       } catch (err) {
         if (err instanceof TypeError) {
           const refClassName = (optionsOrType.ref as Function)?.name;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`ref` can not be correctly inspected in this case:

```javascript
ref: () => Cat.name,
```

## What is the new behavior?

[As mongoose raw supportment](https://github.com/Automattic/mongoose/blob/6.6.5/types/schematypes.d.ts#L84), `ref` function can return a string.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
