### PR TITLE
SchemaFactory trigger an error when a schema doesn't have the @Schema decorator

### DIFF
--- a/lib/factories/definitions.factory.ts
+++ b/lib/factories/definitions.factory.ts
@@ -21,11 +21,12 @@ export class DefinitionsFactory {
         break;
       }
       const schemaMetadata = TypeMetadataStorage.getSchemaMetadataByTarget(
-        parent as Type<unknown>,
+        target as Type<unknown>,
       );
       if (!schemaMetadata) {
-        parent = Object.getPrototypeOf(parent);
-        continue;
+        throw new Error(
+          `Target class "${target}" passed in to the "DefinitionsFactory#createForClass()" method isn't a @Schema.`,
+        );
       }
       schemaMetadata.properties?.forEach((item) => {
         const options = this.inspectTypeDefinition(item.options as any);

--- a/tests/e2e/mongoose.spec.ts
+++ b/tests/e2e/mongoose.spec.ts
@@ -32,6 +32,18 @@ describe('Mongoose', () => {
       });
   });
 
+  it(`should return updated document`, (done) => {
+    const updateDto = { name: 'Nest', breed: 'Maine coon', age: Date.now() };
+    request(server)
+      .put('/cats')
+      .send(updateDto)
+      .expect(200)
+      .end((err, { body }) => {
+        expect(body.modifiedCount).toBeGreaterThan(0);
+        done();
+      });
+  });
+
   afterEach(async () => {
     await app.close();
   });

--- a/tests/e2e/schema.factory.spec.ts
+++ b/tests/e2e/schema.factory.spec.ts
@@ -26,6 +26,17 @@ class ExampleClass {
   array: Array<any>;
 }
 
+class BrokenClass {
+  @Prop({ required: true })
+  children: ChildClass;
+
+  @Prop([ChildClass])
+  nodes: ChildClass[];
+
+  @Prop()
+  array: Array<any>;
+}
+
 describe('SchemaFactory', () => {
   it('should populate the schema options', () => {
     const schema = SchemaFactory.createForClass(ExampleClass) as any;
@@ -49,5 +60,8 @@ describe('SchemaFactory', () => {
         }),
       }),
     );
+  });
+  it('should break the schema', () => {
+    expect(() => SchemaFactory.createForClass(BrokenClass)).toThrow(Error);
   });
 });

--- a/tests/src/cats/cats.controller.ts
+++ b/tests/src/cats/cats.controller.ts
@@ -1,6 +1,6 @@
-import { Body, Controller, Get, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, Put } from '@nestjs/common';
 import { CatsService } from './cats.service';
-import { CreateCatDto } from './dto/create-cat.dto';
+import { CreateCatDto, UpdateCatDto } from './dto';
 import { Cat } from './schemas/cat.schema';
 
 @Controller('cats')
@@ -10,6 +10,11 @@ export class CatsController {
   @Post()
   async create(@Body() createCatDto: CreateCatDto) {
     return this.catsService.create(createCatDto);
+  }
+
+  @Put()
+  async update(@Body() updateCatDto: UpdateCatDto) {
+    return this.catsService.update(updateCatDto);
   }
 
   @Get()

--- a/tests/src/cats/cats.service.ts
+++ b/tests/src/cats/cats.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import { Model } from 'mongoose';
+import { Model, UpdateWriteOpResult } from 'mongoose';
 import { InjectModel } from '../../../lib';
-import { CreateCatDto } from './dto/create-cat.dto';
+import { CreateCatDto, UpdateCatDto } from './dto';
 import { Cat } from './schemas/cat.schema';
 
 @Injectable()
@@ -11,6 +11,12 @@ export class CatsService {
   async create(createCatDto: CreateCatDto): Promise<Cat> {
     const createdCat = new this.catModel(createCatDto);
     return createdCat.save();
+  }
+
+  async update(updateCat: UpdateCatDto): Promise<UpdateWriteOpResult> {
+    const filter = { name: updateCat.name };
+    const updatedCat = this.catModel.updateOne(filter, updateCat);
+    return updatedCat;
   }
 
   async findAll(): Promise<Cat[]> {

--- a/tests/src/cats/dto/index.ts
+++ b/tests/src/cats/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './create-cat.dto';
+export * from './update-cat.dto';

--- a/tests/src/cats/dto/update-cat.dto.ts
+++ b/tests/src/cats/dto/update-cat.dto.ts
@@ -1,0 +1,5 @@
+export class UpdateCatDto {
+  readonly name: string;
+  readonly age: number;
+  readonly breed: string;
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

https://github.com/nestjs/mongoose/issues/1697

Issue Number: 1697


## What is the new behavior?
When you call `SchemaFactory.createForClass` without a `@Schema` throw a new error.
Tests to check update with Schema.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information