### PR TITLE
feat: add lazy connection configuration option

### DIFF
--- a/lib/interfaces/mongoose-options.interface.ts
+++ b/lib/interfaces/mongoose-options.interface.ts
@@ -10,6 +10,7 @@ export interface MongooseModuleOptions
   connectionName?: string;
   connectionFactory?: (connection: any, name: string) => any;
   connectionErrorFactory?: (error: MongooseError) => MongooseError;
+  lazyConnection?: boolean;
 }
 
 export interface MongooseOptionsFactory {

--- a/lib/mongoose-core.module.ts
+++ b/lib/mongoose-core.module.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import * as mongoose from 'mongoose';
+import { Connection, ConnectOptions } from 'mongoose';
 import { defer, lastValueFrom } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { getConnectionToken, handleRetry } from './common/mongoose.utils';
@@ -41,6 +42,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
       connectionName,
       connectionFactory,
       connectionErrorFactory,
+      lazyConnection,
       ...mongooseOptions
     } = options;
 
@@ -48,7 +50,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
       connectionFactory || ((connection) => connection);
 
     const mongooseConnectionError =
-      connectionErrorFactory || ((error) => error);   
+      connectionErrorFactory || ((error) => error);
 
     const mongooseConnectionName = getConnectionToken(connectionName);
 
@@ -56,13 +58,18 @@ export class MongooseCoreModule implements OnApplicationShutdown {
       provide: MONGOOSE_CONNECTION_NAME,
       useValue: mongooseConnectionName,
     };
+
     const connectionProvider = {
       provide: mongooseConnectionName,
       useFactory: async (): Promise<any> =>
         await lastValueFrom(
           defer(async () =>
             mongooseConnectionFactory(
-              await mongoose.createConnection(uri, mongooseOptions).asPromise(),
+              await this.createMongooseConnection(
+                uri,
+                mongooseOptions,
+                lazyConnection,
+              ),
               mongooseConnectionName,
             ),
           ).pipe(
@@ -99,6 +106,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
           uri,
           connectionFactory,
           connectionErrorFactory,
+          lazyConnection,
           ...mongooseOptions
         } = mongooseModuleOptions;
 
@@ -106,14 +114,16 @@ export class MongooseCoreModule implements OnApplicationShutdown {
           connectionFactory || ((connection) => connection);
 
         const mongooseConnectionError =
-        connectionErrorFactory || ((error) => error);
-        
+          connectionErrorFactory || ((error) => error);
+
         return await lastValueFrom(
           defer(async () =>
             mongooseConnectionFactory(
-              await mongoose
-                .createConnection(uri as string, mongooseOptions)
-                .asPromise(),
+              await this.createMongooseConnection(
+                uri,
+                mongooseOptions,
+                lazyConnection,
+              ),
               mongooseConnectionName,
             ),
           ).pipe(
@@ -137,11 +147,6 @@ export class MongooseCoreModule implements OnApplicationShutdown {
       ],
       exports: [connectionProvider],
     };
-  }
-
-  async onApplicationShutdown() {
-    const connection = this.moduleRef.get<any>(this.connectionName);
-    connection && (await connection.close());
   }
 
   private static createAsyncProviders(
@@ -180,5 +185,24 @@ export class MongooseCoreModule implements OnApplicationShutdown {
         await optionsFactory.createMongooseOptions(),
       inject,
     };
+  }
+
+  private static async createMongooseConnection(
+    uri: string,
+    mongooseOptions: ConnectOptions,
+    lazyConnection?: boolean,
+  ): Promise<Connection> {
+    const connection = mongoose.createConnection(uri, mongooseOptions);
+
+    if (lazyConnection) {
+      return connection;
+    }
+
+    return connection.asPromise();
+  }
+
+  async onApplicationShutdown() {
+    const connection = this.moduleRef.get<any>(this.connectionName);
+    connection && (await connection.close());
   }
 }

--- a/tests/e2e/mongoose-lazy-connection.spec.ts
+++ b/tests/e2e/mongoose-lazy-connection.spec.ts
@@ -1,0 +1,38 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { Server } from 'http';
+import * as request from 'supertest';
+import { LazyAppModule } from '../src/lazy-app.module';
+
+describe('Mongoose lazy connection', () => {
+  let server: Server;
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [LazyAppModule],
+    }).compile();
+
+    app = module.createNestApplication();
+    server = app.getHttpServer();
+    await app.init();
+  });
+
+  it(`should return created document`, (done) => {
+    const createDto = { name: 'Nest', breed: 'Maine coon', age: 5 };
+    request(server)
+      .post('/cats')
+      .send(createDto)
+      .expect(201)
+      .end((err, { body }) => {
+        expect(body.name).toEqual(createDto.name);
+        expect(body.age).toEqual(createDto.age);
+        expect(body.breed).toEqual(createDto.breed);
+        done();
+      });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/tests/src/lazy-app.module.ts
+++ b/tests/src/lazy-app.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '../../lib';
+import { CatsModule } from './cats/cats.module';
+
+@Module({
+  imports: [
+    MongooseModule.forRoot('mongodb://localhost:27017/test', {
+      lazyConnection: true,
+    }),
+    CatsModule,
+  ],
+})
+export class LazyAppModule {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The current behavior of the module is that when the connection is injected it also connects to the database. This is caused by the use of `.asPromise()` when creating the connection.

This caused issues for us when we tried starting a service without having mongo up and running.


Issue Number: N/A


## What is the new behavior?
This PR adds a configuration option for the module that enables the use of the module without it connecting automatically when the connection is injected.

The new config interface is:
```typescript
export interface MongooseModuleOptions
  extends ConnectOptions,
    Record<string, any> {
  uri?: string;
  retryAttempts?: number;
  retryDelay?: number;
  connectionName?: string;
  connectionFactory?: (connection: any, name: string) => any;
  connectionErrorFactory?: (error: MongooseError) => MongooseError;
  lazyConnection?: boolean;
}
```


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
