### PR TITLE
feat: add Ref type and type guards

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,4 +4,6 @@ export * from './errors';
 export * from './factories';
 export * from './interfaces';
 export * from './mongoose.module';
+export * from './typeguards';
+export * from './types';
 export * from './utils';

--- a/lib/typeguards/index.ts
+++ b/lib/typeguards/index.ts
@@ -1,0 +1,64 @@
+import { Model, RefType, Types } from 'mongoose';
+import { AllowedRefTypes, DocumentType, Ref } from '../types';
+
+export function isDocument<T, S extends RefType>(
+  doc: Ref<T, S> | null | undefined,
+): doc is DocumentType<T> {
+  return doc instanceof Model;
+}
+
+export function isDocumentArray<T, S extends RefType>(
+  docs: Types.Array<Ref<T, S>> | null | undefined,
+): docs is Types.Array<DocumentType<NonNullable<T>>>;
+
+export function isDocumentArray<T, S extends RefType>(
+  docs: Ref<T, S>[] | null | undefined,
+): docs is DocumentType<NonNullable<T>>[];
+
+export function isDocumentArray(docs: Ref<any, any>[] | null | undefined) {
+  return Array.isArray(docs) && docs.every((v) => isDocument(v));
+}
+
+export function isRefType<T, S extends RefType>(
+  doc: Ref<T, S> | null | undefined,
+  refType: AllowedRefTypes,
+): doc is NonNullable<S> {
+  if (doc == null || isDocument(doc)) {
+    return false;
+  }
+
+  if (refType === Types.ObjectId) {
+    return doc instanceof Types.ObjectId;
+  }
+
+  if (refType === String) {
+    return typeof doc === 'string';
+  }
+
+  if (refType === Number) {
+    return typeof doc === 'number';
+  }
+
+  if (refType === Buffer || refType === Types.Buffer) {
+    return doc instanceof Buffer;
+  }
+
+  return false;
+}
+
+export function isRefTypeArray<T, S extends RefType>(
+  docs: Types.Array<Ref<T, S>> | null | undefined,
+  refType: AllowedRefTypes,
+): docs is Types.Array<NonNullable<S>>;
+
+export function isRefTypeArray<T, S extends RefType>(
+  docs: Ref<T, S>[] | null | undefined,
+  refType: AllowedRefTypes,
+): docs is NonNullable<S>[];
+
+export function isRefTypeArray(
+  docs: Ref<any, any>[] | null | undefined,
+  refType: AllowedRefTypes,
+): unknown {
+  return Array.isArray(docs) && docs.every((v) => isRefType(v, refType));
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,0 +1,22 @@
+import { Document, RefType, Require_id, Types } from 'mongoose';
+
+export type AllowedRefTypes =
+  | typeof String
+  | typeof Number
+  | typeof Buffer
+  | typeof Types.ObjectId
+  | typeof Types.Buffer;
+
+export type DocumentType<T, QueryHelpers = any> = Document<
+  unknown,
+  QueryHelpers,
+  T
+> &
+  Require_id<T>;
+
+export type Ref<
+  T,
+  RawId extends RefType = T extends { _id: RefType }
+    ? T['_id']
+    : Types.ObjectId,
+> = DocumentType<T> | RawId;

--- a/tests/e2e/ref.typeguards.spec.ts
+++ b/tests/e2e/ref.typeguards.spec.ts
@@ -1,0 +1,337 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Types } from 'mongoose';
+
+import {
+  isDocument,
+  isDocumentArray,
+  isRefType,
+  isRefTypeArray,
+  MongooseModule,
+} from '../../lib';
+
+import { PersonModule } from '../src/person/person.module';
+import { PersonService } from '../src/person/person.service';
+import { StoryModule } from '../src/story/story.module';
+import { StoryService } from '../src/story/story.service';
+import { UserModule } from '../src/user/user.module';
+import { UserService } from '../src/user/user.service';
+
+describe('Ref Typeguards', () => {
+  let app: INestApplication;
+  let personService: PersonService;
+  let storyService: StoryService;
+  let userService: UserService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        MongooseModule.forRoot('mongodb://localhost:27017/test'),
+        PersonModule,
+        StoryModule,
+        UserModule,
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    personService = module.get<PersonService>(PersonService);
+    storyService = module.get<StoryService>(StoryService);
+    userService = module.get<UserService>(UserService);
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await personService.model.deleteMany();
+    await storyService.model.deleteMany();
+    await userService.model.deleteMany();
+    await app.close();
+  });
+
+  it('should be defined', () => {
+    expect(app).toBeDefined();
+    expect(personService).toBeDefined();
+    expect(storyService).toBeDefined();
+    expect(userService).toBeDefined();
+  });
+
+  it('should pass the check for single document after population', async () => {
+    const master = await userService.model.create({
+      name: 'master',
+    });
+
+    const sub = await userService.model.create({
+      master: master._id,
+      name: 'sub',
+    });
+
+    await sub.populate('master');
+
+    if (isDocument(sub.master)) {
+      expect(sub.master).not.toBeInstanceOf(Types.ObjectId);
+      expect(sub.master).toBeInstanceOf(userService.model);
+      expect(sub.master.name).toStrictEqual(master.name); // typescript types work well
+    } else {
+      throw new Error("'sub.master' isn't document");
+    }
+  });
+
+  it('should pass the check for array of documents after population', async () => {
+    const sub = await userService.model.create({
+      name: 'sub',
+    });
+
+    const master = await userService.model.create({
+      name: 'master',
+      subs: [sub._id],
+    });
+
+    await master.populate('subs');
+
+    if (isDocumentArray(master.subs)) {
+      expect(Array.isArray(master.subs)).toStrictEqual(true);
+      expect(master.subs).toHaveLength(1);
+      expect(master.subs.at(0)).not.toBeInstanceOf(Types.ObjectId);
+      expect(master.subs.at(0)).toBeInstanceOf(userService.model);
+      expect(master.subs.at(0)?.name).toStrictEqual(sub.name); // typescript types work well
+    } else {
+      throw new Error("'master.subs' isn't array of documents");
+    }
+  });
+
+  it('should pass the check for array of documents after population (mongoose.Types.Array<Ref<T>>)', async () => {
+    const sub = await userService.model.create({
+      name: 'sub',
+    });
+
+    const master = await userService.model.create({
+      name: 'master',
+      susp: [sub._id],
+    });
+
+    await master.populate('susp');
+
+    if (isDocumentArray(master.susp)) {
+      expect(Array.isArray(master.susp)).toStrictEqual(true);
+      expect(master.susp).toHaveLength(1);
+      expect(master.susp.at(0)).not.toBeInstanceOf(Types.ObjectId);
+      expect(master.susp.at(0)).toBeInstanceOf(userService.model);
+      expect(master.susp.at(0)?.name).toStrictEqual(sub.name); // typescript types work well
+    } else {
+      throw new Error("'master.susp' isn't array of documents");
+    }
+  });
+
+  it('should pass the check for single document after depopulation', async () => {
+    const master = await userService.model.create({
+      name: 'master',
+    });
+
+    const sub = await userService.model.create({
+      master: master,
+      name: 'sub',
+    });
+
+    sub.depopulate('master');
+
+    if (!isDocument(sub.master)) {
+      // ts error (as expected):
+      // property 'name' does not exist on type 'ObjectId'
+      // sub.master.name
+      expect(sub.master).not.toHaveProperty('name');
+      expect(sub.master).toBeInstanceOf(Types.ObjectId);
+      expect(sub.master).not.toBeInstanceOf(userService.model);
+    } else {
+      throw new Error("'sub.master' is document");
+    }
+  });
+
+  it('should pass the check for array of documents after depopulation', async () => {
+    const sub = await userService.model.create({
+      name: 'sub',
+    });
+
+    const master = await userService.model.create({
+      name: 'master',
+      subs: [sub],
+    });
+
+    master.depopulate('subs');
+
+    if (!isDocumentArray(master.subs)) {
+      // ts error (as expected):
+      // property 'name' does not exist on type 'ObjectId'
+      // master.subs.at(0)?.name
+      expect(Array.isArray(master.subs)).toStrictEqual(true);
+      expect(master.subs).toHaveLength(1);
+      expect(master.subs.at(0)).not.toHaveProperty('name');
+      expect(master.subs.at(0)).toBeInstanceOf(Types.ObjectId);
+      expect(master.subs.at(0)).not.toBeInstanceOf(userService.model);
+    } else {
+      throw new Error("'master.subs' is array of documents");
+    }
+  });
+
+  it('should pass the check for array of documents after depopulation (mongoose.Types.Array<Ref<T>>)', async () => {
+    const sub = await userService.model.create({
+      name: 'sub',
+    });
+
+    const master = await userService.model.create({
+      name: 'master',
+      susp: [sub],
+    });
+
+    master.depopulate('susp');
+
+    if (!isDocumentArray(master.susp)) {
+      // ts error (as expected):
+      // property 'name' does not exist on type 'ObjectId'
+      // master.susp.at(0)?.name
+      expect(Array.isArray(master.susp)).toStrictEqual(true);
+      expect(master.susp).toHaveLength(1);
+      expect(master.susp.at(0)).not.toHaveProperty('name');
+      expect(master.susp.at(0)).toBeInstanceOf(Types.ObjectId);
+      expect(master.susp.at(0)).not.toBeInstanceOf(userService.model);
+    } else {
+      throw new Error("'master.susp' is array of documents");
+    }
+  });
+
+  it('should pass the checks after population across multiple levels', async () => {
+    const user1 = await userService.model.create({
+      name: 'user-1',
+    });
+
+    const user2 = await userService.model.create({
+      name: 'user-2',
+      master: user1._id,
+    });
+
+    const user3 = await userService.model.create({
+      name: 'user-3',
+      master: user2._id,
+    });
+
+    await user3.populate('master');
+
+    if (isDocument(user3.master)) {
+      // user3.master => user2
+      await user3.master.populate('master');
+
+      if (isDocument(user3.master.master)) {
+        // user3.master.master => user1
+        expect(user3.master.master).not.toBeInstanceOf(Types.ObjectId);
+        expect(user3.master.master).toBeInstanceOf(userService.model);
+        expect(user3.master.master.name).toStrictEqual(user1.name);
+      } else {
+        throw new Error("'user3.master.master' isn't document");
+      }
+    } else {
+      throw new Error("'user3.master' isn't document");
+    }
+  });
+
+  it('should pass the ref type check (ObjectId)', async () => {
+    const master = await userService.model.create({
+      name: 'master',
+    });
+
+    const sub = await userService.model.create({
+      name: 'sub',
+      master,
+    });
+
+    expect(isRefType(sub.master, Types.ObjectId)).toStrictEqual(false);
+    sub.depopulate('master');
+
+    if (isRefType(sub.master, Types.ObjectId)) {
+      // (property) master?: Types.ObjectId
+      expect(sub.master).toBeInstanceOf(Types.ObjectId);
+    } else {
+      throw new Error("'sub.master' isn't ref type of ObjectId");
+    }
+  });
+
+  it('should pass the ref type check (string)', async () => {
+    const leo = await personService.model.create({
+      _id: 'f662eaa1-912a-4789-a4ef-ebc6b6541b9d',
+      age: 82,
+      name: 'Leo Tolstoy',
+    });
+
+    const story = await storyService.model.create({
+      author: leo,
+      title: 'After the Ball',
+    });
+
+    expect(isRefType(story.author, String)).toStrictEqual(false);
+    story.depopulate('author');
+
+    if (isRefType(story.author, String)) {
+      // (property) author: string
+      expect(typeof story.author).toBe('string');
+    } else {
+      throw new Error("'story.author' isn't ref type of string");
+    }
+  });
+
+  it('should pass the ref type check (ObjectId[])', async () => {
+    const sub = await userService.model.create({
+      name: 'sub',
+    });
+
+    const master = await userService.model.create({
+      name: 'master',
+      subs: [sub],
+    });
+
+    expect(isRefTypeArray(master.subs, Types.ObjectId)).toStrictEqual(false);
+    master.depopulate('subs');
+
+    if (isRefTypeArray(master.subs, Types.ObjectId)) {
+      expect(Array.isArray(master.subs)).toStrictEqual(true);
+      expect(master.subs).toHaveLength(1);
+      expect(master.subs.at(0)).toBeInstanceOf(Types.ObjectId);
+    } else {
+      throw new Error("'master.subs' isn't ref type of array of ObjectIds");
+    }
+  });
+
+  it('should pass the ref type check (string[])', async () => {
+    const leo = await personService.model.create({
+      _id: 'f662eaa1-912a-4789-a4ef-ebc6b6541b9d',
+      age: 82,
+      name: 'Leo Tolstoy',
+    });
+
+    const notna = await personService.model.create({
+      _id: '2cd7fdd2-7b41-4796-9dcb-7aef8e007e9c',
+      age: 25,
+      name: 'Notna Nek',
+    });
+
+    const yerdna = await personService.model.create({
+      _id: '229a910b-0ab5-4df7-9523-26677d3028cb',
+      age: 35,
+      name: 'Yerdna Stebok',
+    });
+
+    const story = await storyService.model.create({
+      author: leo,
+      title: 'After the Ball',
+      fans: [notna, yerdna],
+    });
+
+    expect(isRefTypeArray(story.fans, String)).toStrictEqual(false);
+    story.depopulate('fans');
+
+    if (isRefTypeArray(story.fans, String)) {
+      expect(Array.isArray(story.fans)).toStrictEqual(true);
+      expect(story.fans).toHaveLength(2);
+      expect(typeof story.fans.at(0)).toBe('string');
+      expect(typeof story.fans.at(1)).toBe('string');
+    } else {
+      throw new Error("'story.fans' isn't ref type of array of strings");
+    }
+  });
+});

--- a/tests/src/person/person.module.ts
+++ b/tests/src/person/person.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '../../../lib';
+import { Person, PersonSchema } from './person.schema';
+import { PersonService } from './person.service';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Person.name, schema: PersonSchema }]),
+  ],
+  providers: [PersonService],
+  exports: [PersonService],
+})
+export class PersonModule {}

--- a/tests/src/person/person.schema.ts
+++ b/tests/src/person/person.schema.ts
@@ -1,0 +1,18 @@
+import { HydratedDocument } from 'mongoose';
+import { Prop, Schema, SchemaFactory } from '../../../lib';
+
+export type PersonDocument = HydratedDocument<Person>;
+
+@Schema({ _id: false })
+export class Person {
+  @Prop({ required: true })
+  _id: string;
+
+  @Prop({ required: true })
+  age: number;
+
+  @Prop({ required: true })
+  name: string;
+}
+
+export const PersonSchema = SchemaFactory.createForClass(Person);

--- a/tests/src/person/person.service.ts
+++ b/tests/src/person/person.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { Model } from 'mongoose';
+import { InjectModel } from '../../../lib';
+import { Person, PersonDocument } from './person.schema';
+
+@Injectable()
+export class PersonService {
+  constructor(
+    @InjectModel(Person.name) readonly model: Model<PersonDocument>,
+  ) {}
+}

--- a/tests/src/story/story.module.ts
+++ b/tests/src/story/story.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '../../../lib';
+import { Story, StorySchema } from './story.schema';
+import { StoryService } from './story.service';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Story.name, schema: StorySchema }]),
+  ],
+  providers: [StoryService],
+  exports: [StoryService],
+})
+export class StoryModule {}

--- a/tests/src/story/story.schema.ts
+++ b/tests/src/story/story.schema.ts
@@ -1,0 +1,19 @@
+import { HydratedDocument } from 'mongoose';
+import { Prop, Ref, Schema, SchemaFactory } from '../../../lib';
+import { Person } from '../person/person.schema';
+
+export type StoryDocument = HydratedDocument<Story>;
+
+@Schema()
+export class Story {
+  @Prop({ type: String, ref: () => Person })
+  author: Ref<Person, string>;
+
+  @Prop({ required: true })
+  title: string;
+
+  @Prop({ type: [{ type: String, ref: () => Person }] })
+  fans: Ref<Person, string>[];
+}
+
+export const StorySchema = SchemaFactory.createForClass(Story);

--- a/tests/src/story/story.service.ts
+++ b/tests/src/story/story.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import { Model } from 'mongoose';
+import { InjectModel } from '../../../lib';
+import { Story, StoryDocument } from './story.schema';
+
+@Injectable()
+export class StoryService {
+  constructor(@InjectModel(Story.name) readonly model: Model<StoryDocument>) {}
+}

--- a/tests/src/user/user.module.ts
+++ b/tests/src/user/user.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '../../../lib';
+
+import { User, UserSchema } from './user.schema';
+import { UserService } from './user.service';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
+  ],
+  providers: [UserService],
+  exports: [UserService],
+})
+export class UserModule {}

--- a/tests/src/user/user.schema.ts
+++ b/tests/src/user/user.schema.ts
@@ -1,0 +1,27 @@
+import mongoose, { HydratedDocument } from 'mongoose';
+import { Prop, Ref, Schema, SchemaFactory } from '../../../lib';
+
+export type UserDocument = HydratedDocument<User>;
+
+@Schema()
+export class User {
+  @Prop({ required: true })
+  name: string;
+
+  // single ref
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: () => User })
+  master?: Ref<User>;
+
+  // array of ref
+  @Prop({
+    required: true,
+    type: [{ type: mongoose.Schema.Types.ObjectId, ref: () => User }],
+  })
+  subs: Ref<User>[];
+
+  // mongoose.Types.Array of ref
+  @Prop({ type: [{ type: mongoose.Schema.Types.ObjectId, ref: () => User }] })
+  susp: mongoose.Types.Array<Ref<User>>;
+}
+
+export const UserSchema = SchemaFactory.createForClass(User);

--- a/tests/src/user/user.service.ts
+++ b/tests/src/user/user.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import { Model } from 'mongoose';
+import { InjectModel } from '../../../lib';
+import { User, UserDocument } from './user.schema';
+
+@Injectable()
+export class UserService {
+  constructor(@InjectModel(User.name) readonly model: Model<UserDocument>) {}
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1646


## What is the new behavior?

Type `Ref` and type guards `isDocument`, `isDocumentArray`, `isRefType`, `isRefTypeArray` provide compatibility with TypeScript.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
