### PR TITLE
Fix InjectModel decorator for multiple databases

### DIFF
--- a/lib/mongoose.providers.ts
+++ b/lib/mongoose.providers.ts
@@ -7,30 +7,46 @@ export function createMongooseProviders(
   connectionName?: string,
   options: ModelDefinition[] = [],
 ): Provider[] {
-  return options.reduce(
-    (providers, option) => [
+  return options.reduce((providers, option) => {
+    const connectionToken = getConnectionToken(connectionName);
+    const modelToken = getModelToken(option.name, connectionName);
+
+    const modelFactory = (connection: Connection) => {
+      const model = connection.models[option.name]
+        ? connection.models[option.name]
+        : connection.model(option.name, option.schema, option.collection);
+
+      return model;
+    };
+
+    return [
       ...providers,
-      ...(option.discriminators || []).map((d) => ({
-        provide: getModelToken(d.name, connectionName),
-        useFactory: (model: Model<Document>) =>
-          model.discriminator(d.name, d.schema, d.value),
-        inject: [getModelToken(option.name, connectionName)],
-      })),
-      {
-        provide: getModelToken(option.name, connectionName),
-        useFactory: (connection: Connection) => {
-          const model = connection.models[option.name] ? connection.models[option.name] : connection.model(
-            option.name,
-            option.schema,
-            option.collection,
-          );
-          return model;
+      ...(option.discriminators || []).flatMap((d) => [
+        {
+          provide: getModelToken(d.name),
+          useFactory: (model: Model<Document>) =>
+            model.discriminator(d.name, d.schema, d.value),
+          inject: [modelToken],
         },
-        inject: [getConnectionToken(connectionName)],
+        {
+          provide: getModelToken(d.name, connectionName),
+          useFactory: (model: Model<Document>) =>
+            model.discriminator(d.name, d.schema, d.value),
+          inject: [modelToken],
+        },
+      ]),
+      {
+        provide: getModelToken(option.name),
+        useFactory: modelFactory,
+        inject: [connectionToken],
       },
-    ],
-    [] as Provider[],
-  );
+      {
+        provide: modelToken,
+        useFactory: modelFactory,
+        inject: [connectionToken],
+      },
+    ];
+  }, [] as Provider[]);
 }
 
 export function createMongooseAsyncProviders(
@@ -38,27 +54,41 @@ export function createMongooseAsyncProviders(
   modelFactories: AsyncModelFactory[] = [],
 ): Provider[] {
   return modelFactories.reduce((providers, option) => {
+    const connectionToken = getConnectionToken(connectionName);
+    const modelToken = getModelToken(option.name, connectionName);
+
+    const modelFactory = async (connection: Connection, ...args: unknown[]) => {
+      const schema = await option.useFactory(...args);
+      const model = connection.model(option.name, schema, option.collection);
+      return model;
+    };
+
     return [
       ...providers,
       {
-        provide: getModelToken(option.name, connectionName),
-        useFactory: async (connection: Connection, ...args: unknown[]) => {
-          const schema = await option.useFactory(...args);
-          const model = connection.model(
-            option.name,
-            schema,
-            option.collection,
-          );
-          return model;
-        },
-        inject: [getConnectionToken(connectionName), ...(option.inject || [])],
+        provide: modelToken,
+        useFactory: modelFactory,
+        inject: [connectionToken, ...(option.inject || [])],
       },
-      ...(option.discriminators || []).map((d) => ({
-        provide: getModelToken(d.name, connectionName),
-        useFactory: (model: Model<Document>) =>
-          model.discriminator(d.name, d.schema, d.value),
-        inject: [getModelToken(option.name, connectionName)],
-      })),
+      {
+        provide: getModelToken(option.name),
+        useFactory: modelFactory,
+        inject: [connectionToken, ...(option.inject || [])],
+      },
+      ...(option.discriminators || []).flatMap((d) => [
+        {
+          provide: getModelToken(d.name, connectionName),
+          useFactory: (model: Model<Document>) =>
+            model.discriminator(d.name, d.schema, d.value),
+          inject: [modelToken],
+        },
+        {
+          provide: getModelToken(d.name),
+          useFactory: (model: Model<Document>) =>
+            model.discriminator(d.name, d.schema, d.value),
+          inject: [modelToken],
+        },
+      ]),
     ];
   }, [] as Provider[]);
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1938
Since version 9.1.0, the InjectModel decorator for multiple databases is malfunctioning, resulting in an error in resolving dependencies. The only functional approach is to use the connectionName parameter as follows: @InjectModel(modelName, connectionName). It's imperative that this parameter remains optional.


## What is the new behavior?
2 provider tokens created for each model, one with a connectionName and the other without.
connectionName parameter of InjectModel decorator remains optional even for multiple databases

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
