### PR TITLE
chore(deps): Update peer mongoose to include also v8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     working_directory: ~/nest
     docker:
-      - image: cimg/node:20.3
+      - image: cimg/node:20.9
     steps:
       - checkout
       - run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "mongoose": "^6.0.2 || ^7.0.0",
+        "mongoose": "^6.0.2 || ^7.0.0 || ^8.0.0",
         "reflect-metadata": "^0.1.12",
         "rxjs": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "peerDependencies": {
     "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
     "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
-    "mongoose": "^6.0.2 || ^7.0.0",
+    "mongoose": "^6.0.2 || ^7.0.0 || ^8.0.0",
     "reflect-metadata": "^0.1.12",
     "rxjs": "^7.0.0"
   },


### PR DESCRIPTION
All the tests pass successfully with mongoose 8.

Fixes #1937.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Peer dependencies allows only v6 and v7 of mongoose, while v8 was recently released, and the tests pass.

Issue Number: #1937.


## What is the new behavior?
Allow also v8, without changing the direct dependency.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
