### PR TITLE
feat(): add bigint to built-in types

### DIFF
--- a/lib/factories/definitions.factory.ts
+++ b/lib/factories/definitions.factory.ts
@@ -4,7 +4,15 @@ import * as mongoose from 'mongoose';
 import { PropOptions } from '../decorators';
 import { TypeMetadataStorage } from '../storages/type-metadata.storage';
 
-const BUILT_IN_TYPES: Function[] = [Boolean, Number, String, Map, Date, Buffer];
+const BUILT_IN_TYPES: Function[] = [
+  Boolean,
+  Number,
+  String,
+  Map,
+  Date,
+  Buffer,
+  BigInt,
+];
 
 export class DefinitionsFactory {
   static createForClass(target: Type<unknown>): mongoose.SchemaDefinition {

--- a/tests/e2e/schema-definitions.factory.spec.ts
+++ b/tests/e2e/schema-definitions.factory.spec.ts
@@ -79,6 +79,9 @@ class ExampleClass {
 
   @Prop()
   array: Array<any>;
+
+  @Prop()
+  bigint: bigint;
 }
 
 describe('DefinitionsFactory', () => {
@@ -103,6 +106,7 @@ describe('DefinitionsFactory', () => {
       'customObject',
       'any',
       'array',
+      'bigint',
     ]);
     expect(definition).toEqual({
       objectId: {
@@ -130,6 +134,7 @@ describe('DefinitionsFactory', () => {
           },
         },
       ],
+      bigint: { type: BigInt },
       buffer: { type: mongoose.Schema.Types.Buffer },
       decimal: { type: mongoose.Schema.Types.Decimal128 },
       child: {


### PR DESCRIPTION
See: https://mongoosejs.com/docs/schematypes.html#bigint

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
BigInt is not supported as a primitive type

## What is the new behavior?
BigInt is supported by mongoose and will be supported here as well with these changes

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
