### PR TITLE
feat: added onconnectioncreate module option

### DIFF
--- a/lib/interfaces/mongoose-options.interface.ts
+++ b/lib/interfaces/mongoose-options.interface.ts
@@ -1,5 +1,5 @@
 import { ModuleMetadata, Type } from '@nestjs/common';
-import { ConnectOptions, MongooseError } from 'mongoose';
+import { ConnectOptions, MongooseError, Connection } from 'mongoose';
 
 export interface MongooseModuleOptions extends ConnectOptions {
   uri?: string;
@@ -9,6 +9,7 @@ export interface MongooseModuleOptions extends ConnectOptions {
   connectionFactory?: (connection: any, name: string) => any;
   connectionErrorFactory?: (error: MongooseError) => MongooseError;
   lazyConnection?: boolean;
+  onConnectionCreate?: (connection: Connection) => void;
 }
 
 export interface MongooseOptionsFactory {

--- a/lib/interfaces/mongoose-options.interface.ts
+++ b/lib/interfaces/mongoose-options.interface.ts
@@ -8,14 +8,6 @@ export interface MongooseModuleOptions extends ConnectOptions {
   connectionName?: string;
   connectionFactory?: (connection: any, name: string) => any;
   connectionErrorFactory?: (error: MongooseError) => MongooseError;
-  /**
-   * @deprecated Method has been moved to `factoryOptions`
-   */
-  lazyConnection?: boolean;
-  factoryOptions?: MongooseFactoryOptions;
-}
-
-export interface MongooseFactoryOptions {
   lazyConnection?: boolean;
   onConnectionCreate?: (connection: Connection) => void;
 }

--- a/lib/interfaces/mongoose-options.interface.ts
+++ b/lib/interfaces/mongoose-options.interface.ts
@@ -8,6 +8,14 @@ export interface MongooseModuleOptions extends ConnectOptions {
   connectionName?: string;
   connectionFactory?: (connection: any, name: string) => any;
   connectionErrorFactory?: (error: MongooseError) => MongooseError;
+  /**
+   * @deprecated Method has been moved to `factoryOptions`
+   */
+  lazyConnection?: boolean;
+  factoryOptions?: MongooseFactoryOptions;
+}
+
+export interface MongooseFactoryOptions {
   lazyConnection?: boolean;
   onConnectionCreate?: (connection: Connection) => void;
 }

--- a/lib/mongoose-core.module.ts
+++ b/lib/mongoose-core.module.ts
@@ -66,12 +66,10 @@ export class MongooseCoreModule implements OnApplicationShutdown {
         await lastValueFrom(
           defer(async () =>
             mongooseConnectionFactory(
-              await this.createMongooseConnection(
-                uri,
-                mongooseOptions,
+              await this.createMongooseConnection(uri, mongooseOptions, {
                 lazyConnection,
                 onConnectionCreate,
-              ),
+              }),
               mongooseConnectionName,
             ),
           ).pipe(
@@ -125,8 +123,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
               await this.createMongooseConnection(
                 uri as string,
                 mongooseOptions,
-                lazyConnection,
-                onConnectionCreate,
+                { lazyConnection, onConnectionCreate },
               ),
               mongooseConnectionName,
             ),
@@ -194,16 +191,18 @@ export class MongooseCoreModule implements OnApplicationShutdown {
   private static async createMongooseConnection(
     uri: string,
     mongooseOptions: ConnectOptions,
-    lazyConnection?: boolean,
-    onConnectionCreate?: MongooseModuleOptions['onConnectionCreate'],
+    factoryOptions: {
+      lazyConnection?: boolean;
+      onConnectionCreate?: MongooseModuleOptions['onConnectionCreate'];
+    },
   ): Promise<Connection> {
     const connection = mongoose.createConnection(uri, mongooseOptions);
 
-    if (lazyConnection) {
+    if (factoryOptions?.lazyConnection) {
       return connection;
     }
 
-    onConnectionCreate?.(connection);
+    factoryOptions?.onConnectionCreate?.(connection);
 
     return connection.asPromise();
   }

--- a/lib/mongoose-core.module.ts
+++ b/lib/mongoose-core.module.ts
@@ -203,10 +203,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
       return connection;
     }
 
-    const mongooseOnConnectionCreate = onConnectionCreate || (() => {});
-    if (mongooseOnConnectionCreate) {
-      mongooseOnConnectionCreate(connection);
-    }
+    onConnectionCreate?.(connection);
 
     return connection.asPromise();
   }

--- a/lib/mongoose-core.module.ts
+++ b/lib/mongoose-core.module.ts
@@ -43,6 +43,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
       connectionFactory,
       connectionErrorFactory,
       lazyConnection,
+      onConnectionCreate,
       ...mongooseOptions
     } = options;
 
@@ -69,6 +70,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
                 uri,
                 mongooseOptions,
                 lazyConnection,
+                onConnectionCreate,
               ),
               mongooseConnectionName,
             ),
@@ -107,6 +109,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
           connectionFactory,
           connectionErrorFactory,
           lazyConnection,
+          onConnectionCreate,
           ...mongooseOptions
         } = mongooseModuleOptions;
 
@@ -123,6 +126,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
                 uri as string,
                 mongooseOptions,
                 lazyConnection,
+                onConnectionCreate,
               ),
               mongooseConnectionName,
             ),
@@ -191,11 +195,17 @@ export class MongooseCoreModule implements OnApplicationShutdown {
     uri: string,
     mongooseOptions: ConnectOptions,
     lazyConnection?: boolean,
+    onConnectionCreate?: MongooseModuleOptions['onConnectionCreate'],
   ): Promise<Connection> {
     const connection = mongoose.createConnection(uri, mongooseOptions);
 
     if (lazyConnection) {
       return connection;
+    }
+
+    const mongooseOnConnectionCreate = onConnectionCreate || (() => {});
+    if (mongooseOnConnectionCreate) {
+      mongooseOnConnectionCreate(connection);
     }
 
     return connection.asPromise();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1290

```ts
// THIS DOES NOT WORK
MongooseModule.forRootAsync({
  imports: [MongoConfigModule],
  useFactory: async (mongoConfigService: MongoConfigService) => {
    return {
      ...mongoConfigService.mongoConfig,
      connectionFactory: (connection: Connection) => {
        connection.on('connected', () => console.log('connected'));
        connection.on('open', () => console.log('open'));
        connection.on('disconnected', () => console.log('disconnected'));
        connection.on('reconnected', () => console.log('reconnected'));
        connection.on('disconnecting', () => console.log('disconnecting'));

        return connection;
      },
    };
  },
  inject: [MongoConfigService],
}),
```

## What is the new behavior?

According to [Mongoose Documentation](https://mongoosejs.com/docs/connections.html#connection-events), the event listeners should be added immediately after `createConnection`. By adding this `onConnectionCreate` function as a module option, we can bypass the limits of the `connectionFactory` function.

```ts
MongooseModule.forRootAsync({
  imports: [MongoConfigModule],
  useFactory: async (mongoConfigService: MongoConfigService) => {
    return {
      ...mongoConfigService.mongoConfig,
      // Once connection is established
      connectionFactory: (connection: Connection) => {
        connection.plugin(require('mongoose-autopopulate'));

        return connection;
      },
      // Before connection is established and returned as Promise.
      onConnectionCreate: (connection: Connection) => {
        connection.on('connected', () => console.log('connected'));
        connection.on('open', () => console.log('open'));
        connection.on('disconnected', () => console.log('disconnected'));
        connection.on('reconnected', () => console.log('reconnected'));
        connection.on('disconnecting', () => console.log('disconnecting'));

        return connection;
      },
    };
  },
  inject: [MongoConfigService],
}),
```

The same will work for `forRootAsync()`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I can create the Main Docs PR if changes are approved.