### PR TITLE
fix: hide retry message when no retries will be attempted

### DIFF
--- a/lib/common/mongoose.utils.ts
+++ b/lib/common/mongoose.utils.ts
@@ -1,7 +1,7 @@
-import { Logger } from '@nestjs/common';
-import { Observable } from 'rxjs';
-import { delay, retryWhen, scan } from 'rxjs/operators';
-import { DEFAULT_DB_CONNECTION } from '../mongoose.constants';
+import { Logger } from "@nestjs/common";
+import { Observable } from "rxjs";
+import { delay, retryWhen, scan } from "rxjs/operators";
+import { DEFAULT_DB_CONNECTION } from "../mongoose.constants";
 
 export function getModelToken(model: string, connectionName?: string) {
   if (connectionName === undefined) {
@@ -29,12 +29,17 @@ export function handleRetry(
           scan((errorCount, error) => {
             const verboseMessage = verboseRetryLog
               ? ` Message: ${error.message}.`
-              : '';
+              : "";
+            const retryMessage = retryAttempts > 0
+              ? ` Retrying (${errorCount + 1})...`
+              : "";
 
             logger.error(
-              `Unable to connect to the database.${verboseMessage} Retrying (${
-                errorCount + 1
-              })...`,
+              [
+                "Unable to connect to the database.",
+                verboseMessage,
+                retryMessage,
+              ].join(""),
               error.stack,
             );
             if (errorCount + 1 >= retryAttempts) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~ (no test set-up available to test connection failures)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

NestJS logs that a retry will be attempted when configuring the mongoose module with `retryAttempts: 0`:

```
[Nest] 20128  - 07/11/2024, 2:25:55 PM   ERROR [MongooseModule] Unable to connect to the database. Retrying (1)...
[Nest] 20128  - 07/11/2024, 2:25:55 PM   ERROR [ExceptionHandler] Authentication failed.
```

Issue Number: N/A


## What is the new behavior?

Mongoose module does not indicate that a retry will be attempted:

```
[Nest] 20128  - 07/11/2024, 2:25:55 PM   ERROR [MongooseModule] Unable to connect to the database.
[Nest] 20128  - 07/11/2024, 2:25:55 PM   ERROR [ExceptionHandler] Authentication failed.
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
