### PR TITLE
feat: Add ModelWithSchema type for typed model schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ $ npm i --save @nestjs/mongoose mongoose
 
 [Overview & Tutorial](https://docs.nestjs.com/techniques/mongodb)
 
+## Typed model schema
+
+Since `mongoose@9`, the `schema` property of an injected `Model<T>` resolves to `any`, because Mongoose now types it through the model's `TSchema` generic. If you access `model.schema` and want it typed, use the opt-in `ModelWithSchema<T>` type instead of `Model<T>`. It is a drop-in replacement that declares `schema` as `Schema<T>` and leaves everything else unchanged:
+
+```typescript
+import { InjectModel, ModelWithSchema } from '@nestjs/mongoose';
+
+@Injectable()
+export class CatsService {
+  constructor(@InjectModel(Cat.name) private catModel: ModelWithSchema<Cat>) {}
+}
+```
+
+`ModelWithSchema` accepts the same query helpers, instance methods, and virtuals generics as `Model`, and behaves identically under `mongoose@7` and `mongoose@8`, where `schema` is typed out of the box.
+
 ## Support
 
 Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).

--- a/lib/interfaces/index.ts
+++ b/lib/interfaces/index.ts
@@ -1,3 +1,4 @@
 export * from './async-model-factory.interface';
 export * from './model-definition.interface';
+export * from './model-with-schema.interface';
 export * from './mongoose-options.interface';

--- a/lib/interfaces/model-with-schema.interface.ts
+++ b/lib/interfaces/model-with-schema.interface.ts
@@ -1,0 +1,24 @@
+import { HydratedDocument, Model, Schema } from 'mongoose';
+
+/**
+ * Drop-in replacement for `Model<T>` that keeps the `schema` property typed
+ * as `Schema<T>`. Since mongoose@9, `Model.schema` resolves to `any` unless
+ * the `TSchema` generic is supplied explicitly.
+ *
+ * @see https://github.com/nestjs/mongoose/issues/2852
+ *
+ * @publicApi
+ */
+export type ModelWithSchema<
+  TRawDocType,
+  TQueryHelpers = {},
+  TInstanceMethods = {},
+  TVirtuals = {},
+> = Model<
+  TRawDocType,
+  TQueryHelpers,
+  TInstanceMethods,
+  TVirtuals,
+  HydratedDocument<TRawDocType, TVirtuals & TInstanceMethods, TQueryHelpers>,
+  Schema<TRawDocType>
+>;

--- a/tests/e2e/model-with-schema.spec-d.ts
+++ b/tests/e2e/model-with-schema.spec-d.ts
@@ -1,0 +1,59 @@
+import { Model, Schema as MongooseSchema, Types } from 'mongoose';
+import { expectTypeOf } from 'vitest';
+import { ModelWithSchema, Prop, Schema, SchemaFactory } from '../../lib';
+
+@Schema()
+class Cat {
+  @Prop()
+  name: string;
+
+  @Prop()
+  age: number;
+}
+
+const CatSchema = SchemaFactory.createForClass(Cat);
+
+declare const catModel: ModelWithSchema<Cat>;
+declare const plainModel: Model<Cat>;
+
+describe('ModelWithSchema', () => {
+  // see https://github.com/nestjs/mongoose/issues/2852
+  it('should keep the "schema" property typed under mongoose@9', () => {
+    expectTypeOf(catModel.schema).not.toBeAny();
+    expectTypeOf(catModel.schema).toEqualTypeOf<MongooseSchema<Cat>>();
+    expectTypeOf(catModel.schema.obj).not.toBeAny();
+    expectTypeOf(catModel.schema.paths).not.toBeAny();
+  });
+
+  it('should accept the schema created by SchemaFactory', () => {
+    const schema: ModelWithSchema<Cat>['schema'] = CatSchema;
+    expectTypeOf(schema).toEqualTypeOf<MongooseSchema<Cat>>();
+  });
+
+  it('should stay interchangeable with Model<T>', () => {
+    const asPlain: Model<Cat> = catModel;
+    const asTyped: ModelWithSchema<Cat> = plainModel;
+    expectTypeOf(asPlain).not.toBeNever();
+    expectTypeOf(asTyped).not.toBeNever();
+  });
+
+  it('should leave the query surface unchanged', () => {
+    expectTypeOf(catModel.findOne()).toEqualTypeOf(plainModel.findOne());
+    expectTypeOf(new catModel()).toEqualTypeOf(new plainModel());
+    expectTypeOf(new catModel()._id).toEqualTypeOf<Types.ObjectId>();
+  });
+
+  it('should accept query helpers, methods, and virtuals generics', () => {
+    type WithExtras = ModelWithSchema<
+      Cat,
+      { byName(name: string): unknown },
+      { meow(): string },
+      { nameUpper: string }
+    >;
+    expectTypeOf<WithExtras['schema']>().toEqualTypeOf<MongooseSchema<Cat>>();
+  });
+
+  it('documents the mongoose@9 default this type works around', () => {
+    expectTypeOf<Model<Cat>['schema']>().toBeAny();
+  });
+});

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["lib/**/*", "tests/**/*.spec-d.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,5 +14,10 @@ export default defineConfig({
     sequence: {
       concurrent: false,
     },
+    typecheck: {
+      enabled: true,
+      include: ['tests/**/*.spec-d.ts'],
+      tsconfig: './tsconfig.typecheck.json',
+    },
   },
 });


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: closes #2852

Since `mongoose@9` the `schema` property of a model typed as `Model<T>` resolves to `any`. The root cause is upstream. Automattic/mongoose#15750 changed the declaration from `schema: Schema<TRawDocType>` to `schema: TSchema`. A handwritten `Model<T>` annotation omits that generic, which defaults to `any`, and with dependency injection the annotation is the only type source. An upstream fix is proposed in Automattic/mongoose#16406. This PR gives users a solution that works on current mongoose 9 releases.

## What is the new behavior?

A new exported `ModelWithSchema<T>` type. It replaces `Model<T>` and fills the `TSchema` generic with `Schema<T>`, so `model.schema` stays typed. It accepts the same query helpers, instance methods and virtuals generics as `Model`, is assignable in both directions with `Model<T>`, and compiles on mongoose 7, 8 and 9.

Compile time assertions live in `tests/e2e/model-with-schema.spec-d.ts` and run through vitest typecheck inside the existing `npm run test:e2e` command. The `.spec-d.ts` suffix keeps type specs out of the runtime glob.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The typecheck tsconfig sets `types` to `node` and `vitest/globals`, mirroring `tsconfig.build.json`, because `lib/factories/definitions.factory.ts` references `Buffer`.
