### PR TITLE
feat: support waiting for model init before resolving model providers

### DIFF
--- a/lib/common/index.ts
+++ b/lib/common/index.ts
@@ -1,2 +1,6 @@
 export * from './mongoose.decorators.js';
-export { getConnectionToken, getModelToken } from './mongoose.utils.js';
+export {
+  getConnectionToken,
+  getModelToken,
+  getModuleOptionsToken,
+} from './mongoose.utils.js';

--- a/lib/common/mongoose.utils.ts
+++ b/lib/common/mongoose.utils.ts
@@ -1,7 +1,10 @@
 import { Logger } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { delay, retryWhen, scan } from 'rxjs/operators';
-import { DEFAULT_DB_CONNECTION } from '../mongoose.constants.js';
+import {
+  DEFAULT_DB_CONNECTION,
+  MONGOOSE_MODULE_OPTIONS,
+} from '../mongoose.constants.js';
 
 /**
  * @publicApi
@@ -20,6 +23,20 @@ export function getConnectionToken(name?: string) {
   return name && name !== DEFAULT_DB_CONNECTION
     ? `${name}Connection`
     : DEFAULT_DB_CONNECTION;
+}
+
+/**
+ * Returns the injection token for the `MongooseModuleOptions` provider
+ * associated with a given connection, allowing consumers to access the
+ * options a given connection was configured with (e.g. `waitForModelInit`).
+ *
+ * @publicApi
+ */
+export function getModuleOptionsToken(connectionName?: string) {
+  if (connectionName === undefined) {
+    return MONGOOSE_MODULE_OPTIONS;
+  }
+  return `${getConnectionToken(connectionName)}/${MONGOOSE_MODULE_OPTIONS}`;
 }
 
 export function handleRetry(

--- a/lib/decorators/prop.decorator.ts
+++ b/lib/decorators/prop.decorator.ts
@@ -14,7 +14,7 @@ export type PropOptions<T = any> =
 /**
  * @Prop decorator is used to mark a specific class property as a Mongoose property.
  * Only properties decorated with this decorator will be defined in the schema.
- * 
+ *
  * @publicApi
  */
 export function Prop(options?: PropOptions): PropertyDecorator {

--- a/lib/decorators/schema.decorator.ts
+++ b/lib/decorators/schema.decorator.ts
@@ -9,7 +9,7 @@ export type SchemaOptions = mongoose.SchemaOptions;
 /**
  * @Schema decorator is used to mark a class as a Mongoose schema.
  * Only properties decorated with this decorator will be defined in the schema.
- * 
+ *
  * @publicApi
  */
 export function Schema(options?: SchemaOptions): ClassDecorator {

--- a/lib/decorators/virtual.decorator.ts
+++ b/lib/decorators/virtual.decorator.ts
@@ -3,7 +3,7 @@ import { TypeMetadataStorage } from '../storages/type-metadata.storage.js';
 
 /**
  * Interface defining the options that can be passed to the `@Virtual()` decorator.
- * 
+ *
  * @publicApi
  */
 export interface VirtualOptions {
@@ -28,7 +28,7 @@ export interface VirtualOptions {
 
 /**
  * The Virtual decorator marks a class property as a Mongoose virtual.
- * 
+ *
  * @publicApi
  */
 export function Virtual(options?: VirtualOptions): PropertyDecorator {

--- a/lib/interfaces/async-model-factory.interface.ts
+++ b/lib/interfaces/async-model-factory.interface.ts
@@ -5,8 +5,12 @@ import { ModelDefinition } from './model-definition.interface.js';
  * @publicApi
  */
 export interface AsyncModelFactory
-  extends Pick<ModuleMetadata, 'imports'>,
-    Pick<ModelDefinition, 'name' | 'collection' | 'discriminators'> {
+  extends
+    Pick<ModuleMetadata, 'imports'>,
+    Pick<
+      ModelDefinition,
+      'name' | 'collection' | 'discriminators' | 'waitForModelInit'
+    > {
   useFactory: (
     ...args: any[]
   ) => ModelDefinition['schema'] | Promise<ModelDefinition['schema']>;

--- a/lib/interfaces/model-definition.interface.ts
+++ b/lib/interfaces/model-definition.interface.ts
@@ -7,8 +7,15 @@ export type DiscriminatorOptions = {
   name: string;
   schema: Schema;
   value?: string;
+  /**
+   * If `true`, waits for `Model#init()` to resolve before this discriminator
+   * model provider is considered ready. Overrides the connection-wide
+   * `MongooseModuleOptions#waitForModelInit` default.
+   *
+   * @default undefined
+   */
+  waitForModelInit?: boolean;
 };
-
 
 /**
  * @publicApi
@@ -18,4 +25,12 @@ export type ModelDefinition = {
   schema: any;
   collection?: string;
   discriminators?: DiscriminatorOptions[];
+  /**
+   * If `true`, waits for `Model#init()` to resolve before this model
+   * provider is considered ready. Overrides the connection-wide
+   * `MongooseModuleOptions#waitForModelInit` default.
+   *
+   * @default undefined
+   */
+  waitForModelInit?: boolean;
 };

--- a/lib/interfaces/mongoose-options.interface.ts
+++ b/lib/interfaces/mongoose-options.interface.ts
@@ -17,6 +17,16 @@ export interface MongooseModuleOptions extends ConnectOptions {
    * If `true`, will show verbose error messages on each connection retry.
    */
   verboseRetryLog?: boolean;
+  /**
+   * If `true`, model injection (via `@InjectModel()`) will wait for
+   * `Model#init()` to resolve before the model provider is considered
+   * ready, ensuring index building and other initialization has completed
+   * before the model can be used. Can be overridden per model via
+   * `ModelDefinition#waitForModelInit` or `AsyncModelFactory#waitForModelInit`.
+   *
+   * @default false
+   */
+  waitForModelInit?: boolean;
 }
 
 /**
@@ -39,8 +49,10 @@ export type MongooseModuleFactoryOptions = Omit<
 /**
  * @publicApi
  */
-export interface MongooseModuleAsyncOptions
-  extends Pick<ModuleMetadata, 'imports'> {
+export interface MongooseModuleAsyncOptions extends Pick<
+  ModuleMetadata,
+  'imports'
+> {
   connectionName?: string;
   useExisting?: Type<MongooseOptionsFactory>;
   useClass?: Type<MongooseOptionsFactory>;

--- a/lib/mongoose-core.module.ts
+++ b/lib/mongoose-core.module.ts
@@ -12,17 +12,18 @@ import * as mongoose from 'mongoose';
 import { ConnectOptions, Connection } from 'mongoose';
 import { defer, lastValueFrom } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-import { getConnectionToken, handleRetry } from './common/mongoose.utils.js';
+import {
+  getConnectionToken,
+  getModuleOptionsToken,
+  handleRetry,
+} from './common/mongoose.utils.js';
 import {
   MongooseModuleAsyncOptions,
   MongooseModuleFactoryOptions,
   MongooseModuleOptions,
   MongooseOptionsFactory,
 } from './interfaces/mongoose-options.interface.js';
-import {
-  MONGOOSE_CONNECTION_NAME,
-  MONGOOSE_MODULE_OPTIONS,
-} from './mongoose.constants.js';
+import { MONGOOSE_CONNECTION_NAME } from './mongoose.constants.js';
 
 @Global()
 @Module({})
@@ -45,6 +46,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
       lazyConnection,
       onConnectionCreate,
       verboseRetryLog,
+      waitForModelInit: _waitForModelInit,
       ...mongooseOptions
     } = options;
 
@@ -59,6 +61,11 @@ export class MongooseCoreModule implements OnApplicationShutdown {
     const mongooseConnectionNameProvider = {
       provide: MONGOOSE_CONNECTION_NAME,
       useValue: mongooseConnectionName,
+    };
+
+    const moduleOptionsProvider = {
+      provide: getModuleOptionsToken(connectionName),
+      useValue: options,
     };
 
     const connectionProvider = {
@@ -83,13 +90,18 @@ export class MongooseCoreModule implements OnApplicationShutdown {
     };
     return {
       module: MongooseCoreModule,
-      providers: [connectionProvider, mongooseConnectionNameProvider],
-      exports: [connectionProvider],
+      providers: [
+        connectionProvider,
+        mongooseConnectionNameProvider,
+        moduleOptionsProvider,
+      ],
+      exports: [connectionProvider, moduleOptionsProvider],
     };
   }
 
   static forRootAsync(options: MongooseModuleAsyncOptions): DynamicModule {
     const mongooseConnectionName = getConnectionToken(options.connectionName);
+    const moduleOptionsToken = getModuleOptionsToken(options.connectionName);
 
     const mongooseConnectionNameProvider = {
       provide: MONGOOSE_CONNECTION_NAME,
@@ -110,6 +122,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
           lazyConnection,
           onConnectionCreate,
           verboseRetryLog,
+          waitForModelInit: _waitForModelInit,
           ...mongooseOptions
         } = mongooseModuleOptions;
 
@@ -137,7 +150,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
           ),
         );
       },
-      inject: [MONGOOSE_MODULE_OPTIONS],
+      inject: [moduleOptionsToken],
     };
     const asyncProviders = this.createAsyncProviders(options);
     return {
@@ -148,7 +161,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
         connectionProvider,
         mongooseConnectionNameProvider,
       ],
-      exports: [connectionProvider],
+      exports: [connectionProvider, moduleOptionsToken],
     };
   }
 
@@ -171,9 +184,10 @@ export class MongooseCoreModule implements OnApplicationShutdown {
   private static createAsyncOptionsProvider(
     options: MongooseModuleAsyncOptions,
   ): Provider {
+    const moduleOptionsToken = getModuleOptionsToken(options.connectionName);
     if (options.useFactory) {
       return {
-        provide: MONGOOSE_MODULE_OPTIONS,
+        provide: moduleOptionsToken,
         useFactory: options.useFactory,
         inject: options.inject || [],
       };
@@ -183,7 +197,7 @@ export class MongooseCoreModule implements OnApplicationShutdown {
       (options.useClass || options.useExisting) as Type<MongooseOptionsFactory>,
     ];
     return {
-      provide: MONGOOSE_MODULE_OPTIONS,
+      provide: moduleOptionsToken,
       useFactory: async (optionsFactory: MongooseOptionsFactory) =>
         await optionsFactory.createMongooseOptions(),
       inject,

--- a/lib/mongoose.providers.ts
+++ b/lib/mongoose.providers.ts
@@ -1,7 +1,28 @@
 import { Provider } from '@nestjs/common';
 import { Connection, Document, Model } from 'mongoose';
-import { getConnectionToken, getModelToken } from './common/mongoose.utils.js';
-import { AsyncModelFactory, ModelDefinition } from './interfaces/index.js';
+import {
+  getConnectionToken,
+  getModelToken,
+  getModuleOptionsToken,
+} from './common/index.js';
+import {
+  AsyncModelFactory,
+  ModelDefinition,
+  MongooseModuleOptions,
+} from './interfaces/index.js';
+
+async function initModelIfNeeded<
+  TModel extends { init: () => Promise<unknown> },
+>(
+  model: TModel,
+  waitForModelInit: boolean | undefined,
+  moduleOptions: MongooseModuleOptions | undefined,
+): Promise<TModel> {
+  if (waitForModelInit ?? moduleOptions?.waitForModelInit) {
+    await model.init();
+  }
+  return model;
+}
 
 export function createMongooseProviders(
   connectionName?: string,
@@ -12,19 +33,39 @@ export function createMongooseProviders(
       ...providers,
       ...(option.discriminators || []).map((d) => ({
         provide: getModelToken(d.name, connectionName),
-        useFactory: (model: Model<Document>) =>
-          model.discriminator(d.name, d.schema, d.value),
-        inject: [getModelToken(option.name, connectionName)],
+        useFactory: (
+          model: Model<Document>,
+          moduleOptions: MongooseModuleOptions,
+        ) =>
+          initModelIfNeeded(
+            model.discriminator(d.name, d.schema, d.value),
+            d.waitForModelInit,
+            moduleOptions,
+          ),
+        inject: [
+          getModelToken(option.name, connectionName),
+          getModuleOptionsToken(connectionName),
+        ],
       })),
       {
         provide: getModelToken(option.name, connectionName),
-        useFactory: (connection: Connection) => {
+        useFactory: (
+          connection: Connection,
+          moduleOptions: MongooseModuleOptions,
+        ) => {
           const model = connection.models[option.name]
             ? connection.models[option.name]
             : connection.model(option.name, option.schema, option.collection);
-          return model;
+          return initModelIfNeeded(
+            model,
+            option.waitForModelInit,
+            moduleOptions,
+          );
         },
-        inject: [getConnectionToken(connectionName)],
+        inject: [
+          getConnectionToken(connectionName),
+          getModuleOptionsToken(connectionName),
+        ],
       },
     ],
     [] as Provider[],
@@ -40,22 +81,44 @@ export function createMongooseAsyncProviders(
       ...providers,
       {
         provide: getModelToken(option.name, connectionName),
-        useFactory: async (connection: Connection, ...args: unknown[]) => {
+        useFactory: async (
+          connection: Connection,
+          moduleOptions: MongooseModuleOptions,
+          ...args: unknown[]
+        ) => {
           const schema = await option.useFactory(...args);
           const model = connection.model(
             option.name,
             schema,
             option.collection,
           );
-          return model;
+          return initModelIfNeeded(
+            model,
+            option.waitForModelInit,
+            moduleOptions,
+          );
         },
-        inject: [getConnectionToken(connectionName), ...(option.inject || [])],
+        inject: [
+          getConnectionToken(connectionName),
+          getModuleOptionsToken(connectionName),
+          ...(option.inject || []),
+        ],
       },
       ...(option.discriminators || []).map((d) => ({
         provide: getModelToken(d.name, connectionName),
-        useFactory: (model: Model<Document>) =>
-          model.discriminator(d.name, d.schema, d.value),
-        inject: [getModelToken(option.name, connectionName)],
+        useFactory: (
+          model: Model<Document>,
+          moduleOptions: MongooseModuleOptions,
+        ) =>
+          initModelIfNeeded(
+            model.discriminator(d.name, d.schema, d.value),
+            d.waitForModelInit,
+            moduleOptions,
+          ),
+        inject: [
+          getModelToken(option.name, connectionName),
+          getModuleOptionsToken(connectionName),
+        ],
       })),
     ];
   }, [] as Provider[]);

--- a/tests/e2e/wait-for-model-init.spec.ts
+++ b/tests/e2e/wait-for-model-init.spec.ts
@@ -1,0 +1,200 @@
+import { Schema as MongooseSchema, Model } from 'mongoose';
+import { Test } from '@nestjs/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getConnectionToken,
+  getModelToken,
+  MongooseModule,
+} from '../../lib/index.js';
+
+const CONNECTION_NAME = 'wait-for-model-init';
+
+const WidgetSchema = new MongooseSchema({ name: String });
+
+/** Sentinel used to detect whether a promise is still pending. */
+const PENDING = Symbol('pending');
+
+/** Resolves to PENDING if `promise` hasn't settled within a macrotask tick. */
+async function isPending(promise: Promise<unknown>): Promise<boolean> {
+  const result = await Promise.race([
+    promise.catch(() => undefined),
+    new Promise((resolve) => setTimeout(() => resolve(PENDING), 100)),
+  ]);
+  return result === PENDING;
+}
+
+function createDeferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('waitForModelInit', () => {
+  let closeConnection: (() => Promise<void>) | undefined;
+  let initSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  afterEach(async () => {
+    await closeConnection?.().catch(() => undefined);
+    closeConnection = undefined;
+    initSpy?.mockRestore();
+    initSpy = undefined;
+  });
+
+  it('does not block model resolution when disabled (default)', async () => {
+    const deferred = createDeferred();
+    initSpy = vi.spyOn(Model, 'init').mockReturnValue(deferred.promise as any);
+
+    const modulePromise = Test.createTestingModule({
+      imports: [
+        MongooseModule.forRoot('mongodb://localhost:27017/test', {
+          connectionName: CONNECTION_NAME,
+        }),
+        MongooseModule.forFeature(
+          [{ name: 'Widget', schema: WidgetSchema }],
+          CONNECTION_NAME,
+        ),
+      ],
+    }).compile();
+
+    expect(await isPending(modulePromise)).toBe(false);
+
+    const module = await modulePromise;
+    closeConnection = async () =>
+      module.get(getConnectionToken(CONNECTION_NAME)).close();
+    deferred.resolve();
+  });
+
+  it('blocks model resolution until Model#init() resolves when enabled on forRoot', async () => {
+    const deferred = createDeferred();
+    initSpy = vi.spyOn(Model, 'init').mockReturnValue(deferred.promise as any);
+
+    const modulePromise = Test.createTestingModule({
+      imports: [
+        MongooseModule.forRoot('mongodb://localhost:27017/test', {
+          connectionName: CONNECTION_NAME,
+          waitForModelInit: true,
+        }),
+        MongooseModule.forFeature(
+          [{ name: 'Widget', schema: WidgetSchema }],
+          CONNECTION_NAME,
+        ),
+      ],
+    }).compile();
+
+    expect(await isPending(modulePromise)).toBe(true);
+
+    deferred.resolve();
+    const module = await modulePromise;
+    closeConnection = async () =>
+      module.get(getConnectionToken(CONNECTION_NAME)).close();
+
+    const model = module.get(getModelToken('Widget', CONNECTION_NAME));
+    expect(model).toBeDefined();
+  });
+
+  it('propagates a rejected Model#init() when enabled', async () => {
+    initSpy = vi
+      .spyOn(Model, 'init')
+      .mockRejectedValue(new Error('index build failed'));
+
+    await expect(
+      Test.createTestingModule({
+        imports: [
+          MongooseModule.forRoot('mongodb://localhost:27017/test', {
+            connectionName: CONNECTION_NAME,
+            waitForModelInit: true,
+          }),
+          MongooseModule.forFeature(
+            [{ name: 'Widget', schema: WidgetSchema }],
+            CONNECTION_NAME,
+          ),
+        ],
+      }).compile(),
+    ).rejects.toThrow('index build failed');
+  });
+
+  it('allows a per-model override to opt out of the connection-wide default', async () => {
+    const deferred = createDeferred();
+    initSpy = vi.spyOn(Model, 'init').mockReturnValue(deferred.promise as any);
+
+    const modulePromise = Test.createTestingModule({
+      imports: [
+        MongooseModule.forRoot('mongodb://localhost:27017/test', {
+          connectionName: CONNECTION_NAME,
+          waitForModelInit: true,
+        }),
+        MongooseModule.forFeature(
+          [{ name: 'Widget', schema: WidgetSchema, waitForModelInit: false }],
+          CONNECTION_NAME,
+        ),
+      ],
+    }).compile();
+
+    // The per-model override disables the explicit await, so resolution
+    // must not depend on the (still-pending) Model#init() call.
+    expect(await isPending(modulePromise)).toBe(false);
+
+    const module = await modulePromise;
+    closeConnection = async () =>
+      module.get(getConnectionToken(CONNECTION_NAME)).close();
+    deferred.resolve();
+  });
+
+  it('allows a per-model override to opt in when the connection-wide default is disabled', async () => {
+    const deferred = createDeferred();
+    initSpy = vi.spyOn(Model, 'init').mockReturnValue(deferred.promise as any);
+
+    const modulePromise = Test.createTestingModule({
+      imports: [
+        MongooseModule.forRoot('mongodb://localhost:27017/test', {
+          connectionName: CONNECTION_NAME,
+        }),
+        MongooseModule.forFeature(
+          [{ name: 'Widget', schema: WidgetSchema, waitForModelInit: true }],
+          CONNECTION_NAME,
+        ),
+      ],
+    }).compile();
+
+    expect(await isPending(modulePromise)).toBe(true);
+
+    deferred.resolve();
+    const module = await modulePromise;
+    closeConnection = async () =>
+      module.get(getConnectionToken(CONNECTION_NAME)).close();
+  });
+
+  it('supports waitForModelInit on forFeatureAsync', async () => {
+    const deferred = createDeferred();
+    initSpy = vi.spyOn(Model, 'init').mockReturnValue(deferred.promise as any);
+
+    const modulePromise = Test.createTestingModule({
+      imports: [
+        MongooseModule.forRoot('mongodb://localhost:27017/test', {
+          connectionName: CONNECTION_NAME,
+        }),
+        MongooseModule.forFeatureAsync(
+          [
+            {
+              name: 'Widget',
+              useFactory: async () => WidgetSchema,
+              waitForModelInit: true,
+            },
+          ],
+          CONNECTION_NAME,
+        ),
+      ],
+    }).compile();
+
+    expect(await isPending(modulePromise)).toBe(true);
+
+    deferred.resolve();
+    const module = await modulePromise;
+    closeConnection = async () =>
+      module.get(getConnectionToken(CONNECTION_NAME)).close();
+  });
+});


### PR DESCRIPTION
Model index building and other Model#init() work is asynchronous and is never awaited today: MongooseModule resolves model providers as soon as connection.model()/connection.model() returns, without waiting for Model#init() to settle. This can cause race conditions where consumers receive a model whose indexes (or other init-time setup) are not yet built, which is especially problematic in tests that expect unique index constraints to already be enforced.

Add an opt-in `waitForModelInit` option:
- On `MongooseModuleOptions` (forRoot/forRootAsync), as a connection-wide   default.
- On `ModelDefinition`/`DiscriminatorOptions` (forFeature) and   `AsyncModelFactory` (forFeatureAsync), to override the connection-wide   default per model/discriminator.

When enabled, the model provider factory directly awaits `model.init()` before returning the model, so DI resolution (and therefore injection via `@InjectModel()`) genuinely blocks until initialization completes, rather than mutating the model or deferring the wait to a separate lifecycle hook.

To make the connection-wide default available to forFeature/forFeatureAsync providers (which live in separate dynamic modules), `MONGOOSE_MODULE_OPTIONS` is now exported from `MongooseCoreModule` and scoped per-connection via a new `getModuleOptionsToken(connectionName)` helper, mirroring the existing `getConnectionToken`/`getModelToken` convention.
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


## What is the current behavior?
`MongooseModule` resolves model providers as soon as `connection.model()` returns and does not wait for `Model#init()` to finish.

Because `Model#init()` handles asynchronous work such as index creation, consumers can receive an injected model before initialization is complete. This can lead to race conditions, especially in tests or flows that expect unique indexes to already be enforced.

Issue Number: N/A


## What is the new behavior?
This change adds an opt-in `waitForModelInit` option.

When enabled, model provider resolution waits for `model.init()` before returning the model, so injection via `@InjectModel()` only happens after model initialization completes.

The option can be configured:
- globally on `MongooseModuleOptions` (`forRoot` / `forRootAsync`)
- per model on `ModelDefinition` / discriminator options
- per async model factory on `forFeatureAsync`

Per-model configuration can override the connection-wide default.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
This change also introduces a per-connection module options token via `getModuleOptionsToken(connectionName)` so `forFeature` / `forFeatureAsync` providers can access the connection-level `waitForModelInit` default across dynamic modules.
